### PR TITLE
Unbreak build on non-Linux

### DIFF
--- a/showmethekey-cli/main.c
+++ b/showmethekey-cli/main.c
@@ -11,7 +11,9 @@
 #include <getopt.h>
 #include <pthread.h>
 #include <sys/stat.h>
+#if __has_include(<sys/sysmacros.h>)
 #include <sys/sysmacros.h>
+#endif
 
 #include <libudev.h>
 #include <libinput.h>


### PR DESCRIPTION
Regressed by f9dab9d485db. Affects [FreeBSD package](https://www.freshports.org/x11/showmethekey) (build recipe is also used on DragonFly). `major` + `minor` are in `<sys/types.h>` on BSDs, often implicitly included by other headers.

See also https://sourceware.org/bugzilla/show_bug.cgi?id=19239

```c
$ cc --version
FreeBSD clang version 14.0.5 (https://github.com/llvm/llvm-project.git llvmorg-14.0.5-0-gc12386ae247c)
Target: x86_64-unknown-freebsd14.0
Thread model: posix
InstalledDir: /usr/bin

$ meson setup _build
$ meson compile -C _build
[...]
../showmethekey-cli/main.c:14:10: fatal error: 'sys/sysmacros.h' file not found
#include <sys/sysmacros.h>
         ^~~~~~~~~~~~~~~~~
```
