### PR TITLE
build: Use gtk4-update-icon-cache

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -85,7 +85,7 @@ if meson.version().version_compare('>= 0.57.0')
     skip_if_destdir: true
   )
   meson.add_install_script(
-    'gtk-update-icon-cache',
+    'gtk4-update-icon-cache',
     '-f',
     '-t',
     get_option('prefix') / get_option('datadir') / 'icons' / 'hicolor',

--- a/meson_post_install.py
+++ b/meson_post_install.py
@@ -14,6 +14,6 @@ if not os.environ.get("DESTDIR"):
     print(" ".join(argv))
     subprocess.call(argv)
 
-    argv = ["gtk-update-icon-cache", "-f", "-t", icon_dir]
+    argv = ["gtk4-update-icon-cache", "-f", "-t", icon_dir]
     print(" ".join(argv))
     subprocess.call(argv)


### PR DESCRIPTION
Otherwise the build may fail if gtk3 is not presented in the builder sandbox.

```
meson.build:87:8: ERROR: Program 'gtk-update-icon-cache' not found or not executable
```

(Alternatively, [`gnome.post_install()`](https://mesonbuild.com/Gnome-module.html#gnomepost_install) can be used for meson >= 0.57)