### PR TITLE
Add instructions to install on Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,25 @@ Packages can be found in [my OBS project](https://build.opensuse.org/package/sho
 
 Leap users please replace URL for Tumbleweed with URL for your Leap version.
 
+### Fedora
+
+#### Install from COPR
+
+To install the package on Fedora Workstation, run the following commands:
+
+```bash
+sudo dnf copr enable pesader/showmethekey
+sudo dnf install showmethekey
+```
+
+If you are running an Atomic Desktop (Fedora Silverblue, Fedora Kinoite, Fedora Sericea, etc), run:
+
+```bash
+export RELEASE=39 # or whichever release of Fedora you are running
+sudo curl -o /etc/yum.repos.d/showmethekey.repo https://copr.fedorainfracloud.org/coprs/pesader/showmethekey/repo/fedora-$RELEASE/pesader-showmethekey-fedora-$RELEASE.repo
+rpm-ostree install showmethekey
+```
+
 ### Other Distributions
 
 Please help package showmethekey to your distribution!


### PR DESCRIPTION
Hi! I packaged showmethekey for Fedora and made it available as a COPR. This PR adds installation instructions for Fedora in the README.md.

![Screenshot from 2023-10-26 16-35-33](https://github.com/AlynxZhou/showmethekey/assets/65264536/28b936dd-172f-49e0-b4d9-94ba0196348d)

Thank you for developing showmethekey, there's nothing like it out there ⌨️ ❤️

