### PR TITLE
Feat: use Unicode characters for more human-friendly representation

### DIFF
--- a/showmethekey-gtk/smtk-keys-mapper.c
+++ b/showmethekey-gtk/smtk-keys-mapper.c
@@ -182,27 +182,27 @@ static void smtk_keys_mapper_init(SmtkKeysMapper *mapper)
 	// It should be safe to add "Shift+" here, if you want to make some
 	// Shift modified key raw. For example ISO_Left_Tab here.
 	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("ISO_Left_Tab"),
-			    g_strdup("Shift+Tab"));
+			    g_strdup("⭰"));
 	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("Meta_L"),
-			    g_strdup("Meta"));
+			    g_strdup("⊞"));
 	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("Meta_R"),
-			    g_strdup("Meta"));
+			    g_strdup("⊞"));
 	g_hash_table_insert(mapper->xkb_replace_names,
-			    g_strdup("XF86AudioMute"), g_strdup("MuteToggle"));
+			    g_strdup("XF86AudioMute"), g_strdup("🔇"));
 	g_hash_table_insert(mapper->xkb_replace_names,
 			    g_strdup("XF86AudioLowerVolume"),
-			    g_strdup("VolumnDown"));
+			    g_strdup("🔈"));
 	g_hash_table_insert(mapper->xkb_replace_names,
 			    g_strdup("XF86AudioRaiseVolume"),
-			    g_strdup("VolumnUp"));
+			    g_strdup("🔊"));
 	g_hash_table_insert(mapper->xkb_replace_names,
 			    g_strdup("XF86MonBrightnessDown"),
-			    g_strdup("BrightnessDown"));
+			    g_strdup("🔅"));
 	g_hash_table_insert(mapper->xkb_replace_names,
 			    g_strdup("XF86MonBrightnessUp"),
-			    g_strdup("BrightnessUp"));
+			    g_strdup("🔆"));
 	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("Num_Lock"),
-			    g_strdup("NumLock"));
+			    g_strdup("⇭"));
 	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("asciitilde"),
 			    g_strdup("~"));
 	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("grave"),
@@ -248,7 +248,7 @@ static void smtk_keys_mapper_init(SmtkKeysMapper *mapper)
 	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("bar"),
 			    g_strdup("|"));
 	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("Caps_Lock"),
-			    g_strdup("CapsLock"));
+			    g_strdup("⇪"));
 	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("semicolon"),
 			    g_strdup(";"));
 	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("colon"),
@@ -258,9 +258,9 @@ static void smtk_keys_mapper_init(SmtkKeysMapper *mapper)
 	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("quotedbl"),
 			    g_strdup("\""));
 	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("Return"),
-			    g_strdup("Enter"));
+			    g_strdup("⏎"));
 	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("Escape"),
-			    g_strdup("Escape"));
+			    g_strdup("⎋"));
 	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("comma"),
 			    g_strdup(","));
 	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("less"),
@@ -274,29 +274,59 @@ static void smtk_keys_mapper_init(SmtkKeysMapper *mapper)
 	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("question"),
 			    g_strdup("?"));
 	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("space"),
-			    g_strdup("Space"));
+			    g_strdup("⎵"));
 	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("Print"),
-			    g_strdup("PrintScreen"));
+			    g_strdup("⎙"));
 	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("Sys_Req"),
 			    g_strdup("SysReq"));
 	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("Scroll_Lock"),
-			    g_strdup("ScrollLock"));
+			    g_strdup("⇳"));
 	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("Prior"),
-			    g_strdup("PageUp"));
+			    g_strdup("⇞"));
 	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("Next"),
-			    g_strdup("PageDown"));
+			    g_strdup("⇟"));
 	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("BTN_LEFT"),
-			    g_strdup("MouseLeft"));
+			    g_strdup("↖"));
 	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("BTN_RIGHT"),
-			    g_strdup("MouseRight"));
+			    g_strdup("↗"));
 	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("BTN_MIDDLE"),
-			    g_strdup("MouseMiddle"));
+			    g_strdup("↕"));
 	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("BTN_EXTRA"),
-			    g_strdup("MouseForward"));
+			    g_strdup("⏩"));
 	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("BTN_SIDE"),
-			    g_strdup("MouseBack"));
+			    g_strdup("⏪"));
 	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("Num_Lock"),
-			    g_strdup("NumLock"));
+			    g_strdup("⇭"));
+	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("BackSpace"),
+			    g_strdup("⌫"));
+	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("Delete"),
+			    g_strdup("⌦"));
+	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("Tab"),
+			    g_strdup("⇥"));
+	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("Ctrl"),
+			    g_strdup("⌃"));
+	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("Super"),
+			    g_strdup("⌘"));
+	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("Home"),
+			    g_strdup("⇱"));
+	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("End"),
+			    g_strdup("⇲"));
+	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("Left"),
+			    g_strdup("←"));
+	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("Right"),
+			    g_strdup("→"));
+	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("Up"),
+			    g_strdup("↑"));
+	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("Down"),
+			    g_strdup("↓"));
+	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("Shift"),
+			    g_strdup("⇧"));
+	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("Alt"),
+			    g_strdup("⌥"));
+	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("Insert"),
+			    g_strdup("🖉"));
+	g_hash_table_insert(mapper->xkb_replace_names, g_strdup("Pause"),
+			    g_strdup("⏸"));
 }
 
 static void smtk_keys_mapper_class_init(SmtkKeysMapperClass *mapper_class)
@@ -403,10 +433,10 @@ char *smtk_keys_mapper_get_composed(SmtkKeysMapper *mapper, SmtkEvent *event)
 	// I'd like to call it "Super".
 	if (xkb_state_mod_name_is_active(mapper->xkb_state, XKB_MOD_NAME_LOGO,
 					 XKB_STATE_MODS_EFFECTIVE) > 0)
-		g_string_append(buffer, "Super+");
+		g_string_append(buffer, "⌘");
 	if (xkb_state_mod_name_is_active(mapper->xkb_state, XKB_MOD_NAME_CTRL,
 					 XKB_STATE_MODS_EFFECTIVE) > 0)
-		g_string_append(buffer, "Ctrl+");
+		g_string_append(buffer, "⌃");
 	// Shift+Alt will get Meta_L and Meta_R,
 	// and we should not add Alt for it.
 	// I think Meta should be a modifier, but Xkbcommon does not.
@@ -414,7 +444,7 @@ char *smtk_keys_mapper_get_composed(SmtkKeysMapper *mapper, SmtkEvent *event)
 	if (xkb_state_mod_name_is_active(mapper->xkb_state, XKB_MOD_NAME_ALT,
 					 XKB_STATE_MODS_EFFECTIVE) > 0 &&
 	    strcmp(main_key, "Meta") != 0)
-		g_string_append(buffer, "Alt+");
+		g_string_append(buffer, "⌥");
 	if (xkb_state_mod_name_is_active(mapper->xkb_state, XKB_MOD_NAME_SHIFT,
 					 XKB_STATE_MODS_EFFECTIVE) > 0)
 		// Shift is a little bit complex, it can be consumed by
@@ -427,7 +457,7 @@ char *smtk_keys_mapper_get_composed(SmtkKeysMapper *mapper, SmtkEvent *event)
 			    mapper->xkb_state, xkb_key_code,
 			    xkb_keymap_mod_get_index(mapper->xkb_keymap,
 						     XKB_MOD_NAME_SHIFT)))
-			g_string_append(buffer, "Shift+");
+			g_string_append(buffer, "⇧");
 	g_string_append(buffer, main_key);
 	g_free(main_key);
 	return g_string_free(buffer, FALSE);


### PR DESCRIPTION
Perhaps it's more concise to show “^c” instead of “Ctrl-c” as discussed in #42 .