### PR TITLE
Bring back support for libadwaita < 1.5

### DIFF
--- a/showmethekey-gtk/smtk-app-win.c
+++ b/showmethekey-gtk/smtk-app-win.c
@@ -556,8 +556,13 @@ void smtk_app_win_show_usage_dialog(SmtkAppWin *win)
 {
 	g_return_if_fail(win != NULL);
 
+#if ADW_CHECK_VERSION(1, 5, 0)
 	AdwDialog *dialog = adw_alert_dialog_new(
 		_("Usage"),
+#else
+	GtkWidget *dialog = adw_message_dialog_new(
+		GTK_WINDOW(win), _("Usage"),
+#endif
 		_("1. Please input admin password after toggling the switch, "
 		  "because it needs superuser permission to read input events, "
 		  "and Wayland does not allow running graphics program with "
@@ -596,6 +601,7 @@ void smtk_app_win_show_usage_dialog(SmtkAppWin *win)
 		  "6. Set Timeout to 0 if you want to keep all keys.\n\n"
 		  "You can open this dialog again via menu icon on title bar "
 		  "-> \"Usage\"."));
+#if ADW_CHECK_VERSION(1, 5, 0)
 	adw_alert_dialog_set_body_use_markup(ADW_ALERT_DIALOG(dialog), true);
 	adw_alert_dialog_add_response(ADW_ALERT_DIALOG(dialog), "close",
 				      _("Close"));
@@ -603,6 +609,15 @@ void smtk_app_win_show_usage_dialog(SmtkAppWin *win)
 					      "close");
 	adw_alert_dialog_set_close_response(ADW_ALERT_DIALOG(dialog), "close");
 	adw_dialog_present(dialog, GTK_WIDGET(win));
+#else
+	adw_message_dialog_set_body_use_markup(ADW_MESSAGE_DIALOG(dialog),
+					       true);
+	adw_message_dialog_add_response(ADW_MESSAGE_DIALOG(dialog), "close",
+					_("Close"));
+	g_signal_connect_swapped(dialog, "response",
+				 G_CALLBACK(gtk_window_destroy), dialog);
+	gtk_window_present(GTK_WINDOW(dialog));
+#endif
 }
 
 void smtk_app_win_show_about_dialog(SmtkAppWin *win)
@@ -638,7 +653,11 @@ void smtk_app_win_show_about_dialog(SmtkAppWin *win)
 		"governing permissions and\n"
 		"limitations under the License.";
 
+#if ADW_CHECK_VERSION(1, 5, 0)
 	adw_show_about_dialog(GTK_WIDGET(win), "developers", developers,
+#else
+	adw_show_about_window(GTK_WINDOW(win), "developers", developers,
+#endif
 			      "artists", artists, "documenters", documenters,
 			      "translator-credits", _("translator-credits"),
 			      "title", _("About Show Me The Key"),


### PR DESCRIPTION
This amends commit 601ca31505ba30dbdad1e1da7b40070a1b223f8c, which updated the code to the new libadwaita 1.5 APIs.

Fixes https://github.com/AlynxZhou/showmethekey/issues/61