### PR TITLE
Fix typo in application help

### DIFF
--- a/showmethekey-gtk/po/es_ES.po
+++ b/showmethekey-gtk/po/es_ES.po
@@ -26,7 +26,7 @@ msgid "Display version then exit."
 msgstr "Mostrar versión y salir."
 
 #: showmethekey-gtk/smtk-app.c:114
-msgid "Show keys window on start up (deprecated by `-k, --show-keys-win`)."
+msgid "Show keys window on start up (deprecated by `-k, --keys-win`)."
 msgstr ""
 
 #: showmethekey-gtk/smtk-app.c:117

--- a/showmethekey-gtk/po/showmethekey.pot
+++ b/showmethekey-gtk/po/showmethekey.pot
@@ -27,7 +27,7 @@ msgid "Display version then exit."
 msgstr ""
 
 #: showmethekey-gtk/smtk-app.c:114
-msgid "Show keys window on start up (deprecated by `-k, --show-keys-win`)."
+msgid "Show keys window on start up (deprecated by `-k, --keys-win`)."
 msgstr ""
 
 #: showmethekey-gtk/smtk-app.c:117

--- a/showmethekey-gtk/po/zh_CN.po
+++ b/showmethekey-gtk/po/zh_CN.po
@@ -26,8 +26,8 @@ msgid "Display version then exit."
 msgstr "显示版本号然后退出。"
 
 #: showmethekey-gtk/smtk-app.c:114
-msgid "Show keys window on start up (deprecated by `-k, --show-keys-win`)."
-msgstr "在启动时显示按键窗口（已废弃，请使用 `-k, --show-keys-win`）。"
+msgid "Show keys window on start up (deprecated by `-k, --keys-win`)."
+msgstr "在启动时显示按键窗口（已废弃，请使用 `-k, --keys-win`）。"
 
 #: showmethekey-gtk/smtk-app.c:117
 msgid "Show keys window on start up."

--- a/showmethekey-gtk/smtk-app.c
+++ b/showmethekey-gtk/smtk-app.c
@@ -111,7 +111,7 @@ static void smtk_app_init(SmtkApp *app)
 		  N_("Display version then exit."), NULL },
 		// Keep this option because I don't want to break CLI.
 		{ "active", 'a', 0, G_OPTION_ARG_NONE, NULL,
-		  N_("Show keys window on start up (deprecated by `-k, --show-keys-win`)."),
+		  N_("Show keys window on start up (deprecated by `-k, --keys-win`)."),
 		  NULL },
 		{ "keys-win", 'k', 0, G_OPTION_ARG_NONE, NULL,
 		  N_("Show keys window on start up."), NULL },


### PR DESCRIPTION
The `--help` of GTK application mentions that the `--active` option is deprecated by `--show-keys-win` option. However, there is no such option available – it meant to refer to `--keys-win` instead. This pull request fixes the help message.

Spotted in latest release:
```
[sdatko@altair ~]$ showmethekey-gtk --version
1.19.0
```

Example of current help message:
```
[sdatko@altair ~]$ showmethekey-gtk --help
Usage:
  showmethekey-gtk [OPTION…]

Help Options:
  -h, --help                Show help options
  --help-all                Show all help options
  --help-gapplication       Show GApplication options

Application Options:
  -v, --version             Display version then exit.
  -a, --active              Show keys window on start up (deprecated by `-k, --show-keys-win`).
  -k, --keys-win            Show keys window on start up.
  -A, --no-app-win          Hide app window and show keys window on start up.
  -C, --no-clickable        Make keys window unclickable on start up.
```

Just for verification:
```
[sdatko@altair ~]$ showmethekey-gtk --show-keys-win
Unknown option --show-keys-win
```

For the record, changes in this PR I just made with:
`sed -i -e 's#show-keys-win#keys-win#g' */*.c */*/*.po */*/*.pot`